### PR TITLE
User feedback on failure during device connection

### DIFF
--- a/app/renderer.js
+++ b/app/renderer.js
@@ -129,7 +129,6 @@ function bleHandler() {
       deviceDOM.classList.add('connected');
       deviceDOM.querySelector('img').addEventListener('click', () => device.gatt.disconnect());
     } catch (err) {
-
       alert(`Bluetooth MIDI connection failed: ${err?.message ?? err}`);
 
       if (!device) {

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -119,12 +119,19 @@ function bleHandler() {
       characteristic.addEventListener('characteristicvaluechanged', bridge.handleInput);
       progress.value = '0.9';
 
+      if (!characteristic.properties.notify && !characteristic.properties.indicate) {
+        throw new Error('Characteristic does not support notify/indicate');
+      }
+
       await characteristic.startNotifications();
       progress.value = '1';
 
       deviceDOM.classList.add('connected');
       deviceDOM.querySelector('img').addEventListener('click', () => device.gatt.disconnect());
-    } catch {
+    } catch (err) {
+
+      alert(`Bluetooth MIDI connection failed: ${err?.message ?? err}`);
+
       if (!device) {
         if (devicesDialog.open) devicesDialog.close();
         if (resolveSelection) resolveSelection();


### PR DESCRIPTION
Adds some user feedback if the application fails during device connection. 

I was having issues with connecting my keyboard over BLE-MIDI and could not figure out why this was happening. This helped me solve it, maybe it will save someone else a couple of hours in the future :-)